### PR TITLE
Disable default language select

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
 		{
 			"name": "Teemu Suoranta",
 			"email": "teemu@aucor.fi"
+		},
+		{
+			"name": "Timi Wahalahti",
+			"email": "timi@wahalahti.fi"
 		}
 	]
 }

--- a/polylang-smart-language-select-disabler.php
+++ b/polylang-smart-language-select-disabler.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Polylang Add-on: Smart Language Select Disabler
 Plugin URI:
-Version: 1.0.3
+Version: 1.1.0
 Author: Aucor Oy
 Author URI: https://github.com/aucor
 Description: Disable content language select when there's translations in Polylang

--- a/polylang-smart-language-select-disabler.php
+++ b/polylang-smart-language-select-disabler.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Polylang Add-on: Smart Language Select Disabler
-Plugin URI: 
+Plugin URI:
 Version: 1.0.3
 Author: Aucor Oy
 Author URI: https://github.com/aucor
@@ -20,9 +20,10 @@ class PolylangSmartLanguageSelectDisabler {
 
 		// Check that Polylang is active
 		global $polylang;
-		
+
 		if (isset($polylang)) {
 			add_action('current_screen', array(&$this, 'maybe_disable_language_select'));
+			add_action('pll_default_lang_row_action', array(&$this, 'maybe_disable_default_language_select'), 10, 2);
 		}
 	}
 
@@ -62,8 +63,7 @@ class PolylangSmartLanguageSelectDisabler {
 			}
 
 		}
-		
-		
+
 		// Posts bulk edit
 		if( $current_screen->base === 'edit' ) {
 			$disable_translations = true;
@@ -76,7 +76,6 @@ class PolylangSmartLanguageSelectDisabler {
 
 		// Give filter to add custom logic for disabler
 		$disable_translations = apply_filters( 'polylang-disable-language-select', $disable_translations, $current_screen );
-
 
 		if ($disable_translations) {
 
@@ -166,6 +165,33 @@ class PolylangSmartLanguageSelectDisabler {
 			});
 		}
 
+	}
+
+	/**
+	 *  Maybe disable Polylang default language change select
+	 *
+	 *  @param  string $s    html markup of the action
+	 *  @param  object $item
+	 *  @return string
+	 */
+	function maybe_disable_default_language_select( $s, $item ) {
+		$disable = true;
+
+		// Give get parameter to allow chaning the default language
+		if ( isset( $_GET['iknowwhatimdoing'] ) ) {
+			$disable = false;
+		}
+
+		// Give filter to add custom logic for disabler
+		$disable = apply_filters( 'polylang-disable-default-language-select', $disable, $item );
+
+		// Return empty string if disabled
+		if ( $disable ) {
+			return '';
+		}
+
+		// Return original string containing link to change
+		return $s;
 	}
 
 }

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Changing the site default language is prone to errors. Even though the language 
 
  * Checks if currently edited post or term has translations
  * If it has, hides select and shows the name of current language with CSS and vanilla JS
- * Removes option to change default language unless user does not provide `iknowwhatimdoing` GET-parameter or allows it via filter
+ * Removes option to change default language unless the user does not provide `iknowwhatimdoing` GET-parameter or allows it via filter
 
 ## Installation
 
@@ -78,7 +78,7 @@ add_filter('polylang-disable-default-language-select', '__return_true');
 
 ### 1.1.0 Disable default language change select
 
-Chaning site default language will probably cause some issues if you don't know what you are doing. Disable the availability to do so, unless user know what they are doing.
+Changing site default language will probably cause some issues if you don't knows what you are doing. Disable the availability to do so, unless the user know what they are doing.
 
 ### 1.0.2 Remove `create_function` usage and include license
 

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,12 @@
 # Polylang Add-on: Smart Language Select Disabler
 
-**Contributors:** [Teemu Suoranta](https://github.com/TeemuSuoranta)
+**Contributors:** [Teemu Suoranta](https://github.com/TeemuSuoranta), [Timi Wahalahti](https://github.com/timiwahalahti)
 
 **Tags:** Polylang, Admin, Language Select, WordPress
 
 **License:** GPLv2 or later
 
 ![polylang-smart-disable-language-select](https://user-images.githubusercontent.com/9577084/28357103-fa19a40c-6c72-11e7-8901-06700b4b4384.jpg)
-
 
 ## Why this plugin exists?
 
@@ -23,11 +22,15 @@ I've seen that users have multiple times changed post's language when they meant
 
 Changing the language of post when it has content is prone to errors. Even though the language can be changed, the images added to content may still be in wrong language. Custom fields, relations etc are not automatically changed. Language should be changed right away before adding content.
 
+### Changing the site default language is risky business anyway
+
+Changing the site default language is prone to errors. Even though the language can be changed, links in content may still be in wrong language. Custom fields, relations etc are not automatically changed. Language should be changed only if user knows what they are doing.
+
 ## What it does?
 
  * Checks if currently edited post or term has translations
  * If it has, hides select and shows the name of current language with CSS and vanilla JS
-
+ * Removes option to change default language unless user does not provide `iknowwhatimdoing` GET-parameter or allows it via filter
 
 ## Installation
 
@@ -62,12 +65,20 @@ function my_polylang_disable_language_select($disable_select, $current_screen) {
 add_filter('polylang-disable-language-select', 'my_polylang_disable_language_select', 10, 2);
 ```
 
+Allow default language change:
+```
+add_filter('polylang-disable-default-language-select', '__return_true');
+```
 
 ## Issues
 
  * No disabling for media (to-do)
  
 ## Releases
+
+### 1.1.0 Disable default language change select
+
+Chaning site default language will probably cause some issues if you don't know what you are doing. Disable the availability to do so, unless user know what they are doing.
 
 ### 1.0.2 Remove `create_function` usage and include license
 


### PR DESCRIPTION
As discussed in #6, changing site default language will probably cause some issues if you don't know what you are doing. Disable the availability to do so, unless the user knows what they are doing.

Remove option to change default language unless the user does not provide `iknowwhatimdoing` GET-parameter or allows it via `polylang-disable-default-language-select` filter.

```
add_filter('polylang-disable-default-language-select', '__return_true');
```